### PR TITLE
Cleaned up FOOOF Matlab implementation and options panel

### DIFF
--- a/toolbox/misc/bst_prctile.m
+++ b/toolbox/misc/bst_prctile.m
@@ -1,0 +1,48 @@
+function value = bst_prctile(vector, percentile)
+% BST_PRCTILE: Returns the percentile value in vector
+%
+% USAGE: value = bst_prctile(vector, percentile)
+
+% @=============================================================================
+% This function is part of the Brainstorm software:
+% https://neuroimage.usc.edu/brainstorm
+% 
+% Copyright (c)2000-2020 University of Southern California & McGill University
+% This software is distributed under the terms of the GNU General Public License
+% as published by the Free Software Foundation. Further details on the GPLv3
+% license can be found at http://www.gnu.org/copyleft/gpl.html.
+% 
+% FOR RESEARCH PURPOSES ONLY. THE SOFTWARE IS PROVIDED "AS IS," AND THE
+% UNIVERSITY OF SOUTHERN CALIFORNIA AND ITS COLLABORATORS DO NOT MAKE ANY
+% WARRANTY, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+% MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, NOR DO THEY ASSUME ANY
+% LIABILITY OR RESPONSIBILITY FOR THE USE OF THIS SOFTWARE.
+%
+% For more information type "brainstorm license" at command prompt.
+% =============================================================================@
+%
+% Authors: Martin Cousineau, 2020
+
+% Try to use toolbox function
+try
+    value = prctile(vector, percentile);
+    return;
+catch
+end
+
+if ~isvector(vector)
+    error('Only vectors supported.');
+end
+
+% Custom implementation
+vector = sort(vector);
+rank   = percentile / 100 * (length(vector) + 1);
+lowerRank = floor(rank);
+upperRank = ceil(rank);
+fraction  = rank - lowerRank;
+
+if fraction == 0
+    value = vector(rank);
+else
+    value = fraction * (vector(upperRank) - vector(lowerRank)) + vector(lowerRank);
+end


### PR DESCRIPTION
* Removed unnecessary ctrl global variable
* Replaced toolbox-only functions so users can run the process with vanilla Matlab
* Replaced some newer Matlab functions to ensure compatibility with older versions of Matlab
* Now the options panel values are saved only on the OK click and not reset when you edit the options again